### PR TITLE
fix: reload dnsmasq after DNS config changes

### DIFF
--- a/luci-app-fchomo/root/etc/init.d/fchomo
+++ b/luci-app-fchomo/root/etc/init.d/fchomo
@@ -451,7 +451,7 @@ start_service() {
 }
 
 service_started() {
-	procd_set_config_changed dnsmasq
+	procd_set_config_changed dhcp
 	procd_set_config_changed firewall
 }
 
@@ -528,7 +528,7 @@ service_stopped() {
 	[ -n "$(/etc/init.d/$CONF info | jsonfilter -q -e '@.'"$CONF"'.instances["mihomo-c"]')" ] || client_stopped
 	# Server
 
-	procd_set_config_changed dnsmasq
+	procd_set_config_changed dhcp
 	procd_set_config_changed firewall
 }
 


### PR DESCRIPTION
## Summary

Use the `dhcp` UCI package name when notifying procd that dnsmasq configuration has changed.

## Problem

The dnsmasq init script registers its reload trigger with:

```sh
procd_add_reload_trigger "dhcp" "system"
```

fchomo currently emits `config.change` for `dnsmasq` after starting or stopping. Since no dnsmasq trigger watches that package name, the generated fchomo dnsmasq include files are not loaded until dnsmasq is manually restarted or reloaded.

This is visible when a DNS policy is changed to forward selected queries to AdGuard Home: fchomo writes the new `server=` entry, but queries do not reach AdGuard Home until dnsmasq is restarted.

## Fix

Change both lifecycle notifications from:

```sh
procd_set_config_changed dnsmasq
```

to:

```sh
procd_set_config_changed dhcp
```

## Validation

Tested on OpenWrt 25.12.5 with luci-app-fchomo built from `cf07675`:

- monitored ubus events during `/etc/init.d/fchomo reload`;
- confirmed the `dhcp` config change matched dnsmasq's procd trigger;
- confirmed dnsmasq reloaded after fchomo regenerated its include files;
- confirmed DNS queries reached the configured AdGuard Home upstream without a manual dnsmasq restart;
- `sh -n luci-app-fchomo/root/etc/init.d/fchomo` passes.
